### PR TITLE
null check library info

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "contentType": "Library",
   "majorVersion": 1,
   "minorVersion": 24,
-  "patchVersion": 15,
+  "patchVersion": 16,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/src/scripts/cp.js
+++ b/src/scripts/cp.js
@@ -778,11 +778,14 @@ CoursePresentation.prototype.resize = function () {
 
     for (let i = 0; i < instances.length; i++) {
       const instance = instances[i];
-      if (instance.libraryInfo.machineName === "H5P.Dialogcards") {
+
+      const isDialogCards = instance.libraryInfo && instance.libraryInfo.machineName === "H5P.Dialogcards";
+      if (isDialogCards) {
         instance.on('resize', function () {
           self.resizeDialogCard(this);
         });
       }
+
       if ((instance.preventResize === undefined || instance.preventResize === false) && instance.$ !== undefined && !slideElements[i].displayAsButton) {
         H5P.trigger(instance, 'resize');
       }


### PR DESCRIPTION
Not all library instances have `libraryInfo` set. One example is `Hotspot`, a type that only exists in this project.